### PR TITLE
Allow PassFF Integration

### DIFF
--- a/www/aw.js
+++ b/www/aw.js
@@ -202,13 +202,13 @@ $( document ).ready(function() {
     let url = urlParam('url');
     let apikey = urlParam('apikey');
 
-    $("#callparams [name='tr_uri']").val(url)
+    $("#callparams [name='tr_redmine']").val(url)
     $("#callparams [name='tr_apikey']").val(apikey)
 
     loadActionables(url, apikey);
 
     $("#load").click(function(event) {
-        let url = $("#callparams [name='tr_uri']").val()
+        let url = $("#callparams [name='tr_redmine']").val()
         let apikey = $("#callparams [name='tr_apikey']").val()
 
         var newurl = '?url='+encodeURIComponent(url)+ '&apikey='+encodeURIComponent(apikey);

--- a/www/index.html
+++ b/www/index.html
@@ -21,8 +21,8 @@
                 <form id="callparams">
                     <div>
                         <div>
-                            <label for="tr_uri">URI:</label>
-                            <input type="text" name="tr_uri" />
+                            <label for="tr_redmine">Redmine Instance URL:</label>
+                            <input type="text" name="tr_redmine" />
                         </div>
                         <div>
                             <label for="tr_apikey">API Key:</label>


### PR DESCRIPTION
PassFF is a browser plugin that uses the password-store.org based
password database to fill forms on firefox. For this it guesses from the
form elements which fields should be entered. Apparently the URI-field
names are filled with usernames or the url of the site that is visisted.
As such the passFF integration breaks usability.

This renames the tr_uri to tr_redmine to avoid this behavior. Also the
label is adjusted for clarification