### PR TITLE
:green_heart: Update runner for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: "Release"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Check-out"
         uses: actions/checkout@v3


### PR DESCRIPTION
The runner ubuntu-18.04 is no longer available, switch to ubuntu-latest to avoid future issues.

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/