### PR TITLE
Fix push-to-registry expression

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -72,4 +72,4 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           # Limit to tagged releases to avoid attesting every single merge to main
-          push-to-registry: startsWith(github.ref, 'refs/tags/v')
+          push-to-registry: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
This pull request includes a minor fix to the Docker image GitHub Actions workflow. The change ensures that the `push-to-registry` parameter uses the correct syntax for GitHub Actions expressions, improving workflow reliability.