### PR TITLE
Add LICENSE and extend Copyright to 2025

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright 2020-2025 Stefan Haun and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ If possible, please stick to the following guidelines:
 
 ## License
 
-MIT © 2020-2023 Stefan Haun and contributors
+MIT © 2020-2025 Stefan Haun and contributors

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ If possible, please stick to the following guidelines:
 
 ## License
 
-MIT © 2020-2025 Stefan Haun and contributors
+[MIT](LICENSE.txt) © 2020-2025 Stefan Haun and contributors


### PR DESCRIPTION
This pull request updates the project's licensing information to ensure accuracy and clarity. The most important changes are:

**Licensing Updates:**

* Added a new `LICENSE.txt` file containing the full MIT license text, including updated copyright years (2020-2025) and contributor information.
* Updated the license section in `README.md` to reference the new `LICENSE.txt` file and reflect the revised copyright years.