### PR TITLE
Add an optional horizontal scroll bar for pre-formatted blocks

### DIFF
--- a/www/aw.css
+++ b/www/aw.css
@@ -255,3 +255,8 @@ div.actionable div.project .title::before {
     padding-right: 10px;
 }
 
+/* Optionally show a horizontal scrollbar for wide code blocks */
+div.actionable div.details pre {
+  max-width: 100%;
+  overflow-x: auto;
+}


### PR DESCRIPTION
In the actionable details view, show a horizontal scroll bar if the block reaches past the boundary of the containing.

Fixes #19 

Long line with scrollbar:
<img width="1033" height="73" alt="image" src="https://github.com/user-attachments/assets/b9fb491b-0ff1-45b3-ad7d-b7e20bcce6da" />

Short line without scrollbar:
<img width="1030" height="99" alt="image" src="https://github.com/user-attachments/assets/b92530b6-cf05-43ea-851e-eb7dd699cc04" />
