### PR TITLE
Suppress concurrent docker builds on the same branch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: docker.io
   IMAGE_NAME: mrtux/actionables-web


### PR DESCRIPTION
Save on resources by canceling a Docker build if there is a newer workflow on the same branch.